### PR TITLE
Installed react-calendly and added a popup button

### DIFF
--- a/components/landing-page/Banner.jsx
+++ b/components/landing-page/Banner.jsx
@@ -8,6 +8,7 @@ const navigation = [
   {name: 'About', href: '/about', current: false},
   {name: 'Pricing', href: '#pricing', current: false},
   {name: 'Docs', href: '/docs', current: false},
+  {name: 'Contact', href: '/contact', current: false},
 ]
 
 export default function Banner() {

--- a/components/landing-page/Banner.jsx
+++ b/components/landing-page/Banner.jsx
@@ -185,7 +185,8 @@ export default function Banner() {
                         </a>
                       </div>
                       <div className="mt-3 sm:mt-0 sm:ml-3">
-                        <PopupButton url="https://calendly.com/dansult" text="Book a demo"
+                        <PopupButton url="https://calendly.com/dansult"
+                                     text="Book a demo"
                                      className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 md:py-4 md:text-lg md:px-10"
                         />
                       </div>

--- a/components/landing-page/Banner.jsx
+++ b/components/landing-page/Banner.jsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react'
 import {Popover, Transition} from '@headlessui/react'
 import {MenuIcon, XIcon} from '@heroicons/react/outline'
 import {ChevronRightIcon} from '@heroicons/react/solid'
+import {PopupButton} from "react-calendly";
 
 const navigation = [
   {name: 'About', href: '/about', current: false},
@@ -10,6 +11,7 @@ const navigation = [
 ]
 
 export default function Banner() {
+
   return (
     <div className="min-h-0">
       <div className="relative overflow-hidden">
@@ -182,12 +184,9 @@ export default function Banner() {
                         </a>
                       </div>
                       <div className="mt-3 sm:mt-0 sm:ml-3">
-                        <a
-                          href="/contact"
-                          className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 md:py-4 md:text-lg md:px-10"
-                        >
-                          Book a demo
-                        </a>
+                        <PopupButton url="https://calendly.com/dansult" text="Book a demo"
+                                     className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 md:py-4 md:text-lg md:px-10"
+                        />
                       </div>
                     </div>
 

--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -7,6 +7,7 @@ const navigation = [
   {name: 'About', href: '/about', current: false},
   {name: 'Pricing', href: '/#pricing', current: false},
   {name: 'Docs', href: '/docs', current: false},
+  {name: 'Contact', href: '/contact', current: false},
 ]
 const userActions = [
   {name: 'Login', href: '/login', current: false},

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "postcss": "^8.3.0",
     "raw-loader": "^4.0.2",
     "react": "17.0.2",
+    "react-calendly": "^2.0.4",
     "react-dom": "17.0.2",
     "remark": "^13.0.0",
     "remark-html": "^13.0.1",

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -4,6 +4,7 @@ import {
   ShieldExclamationIcon,
   SupportIcon
 } from "@heroicons/react/outline";
+import {PopupButton} from "react-calendly";
 
 const issueGithub = 'https://github.com/mudmapio/public-interactions/issues/new/choose'
 const supportLinks = [
@@ -50,8 +51,15 @@ export default function Contact() {
               <p className="mt-6 max-w-3xl text-xl text-gray-300">
                 Check the boxes below to see which area most suits your needs.
                 If you feel that none of those apply then you can reach me via
-                email at <span className="underline">dan@mudmap.io</span>
+                email at <span
+                className="underline">dan@mudmap.io</span> or <span>
+                <PopupButton url="https://calendly.com/dansult"
+                             text="book a demo"
+                             className="underline"
+                />
+                </span>
               </p>
+
               <p className="mt-6 max-w-3xl text-xl text-gray-300">
                 Hope you find what you're looking for.
               </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,6 +2956,11 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+react-calendly@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-calendly/-/react-calendly-2.0.4.tgz#68f6775ee3c351205e705af24d82a21f20f5a340"
+  integrity sha512-niITyo6k3P/3mx/D0XTG3h4py35rVLgwbcv5DmieBBVw/xhmFHdmg3BR0A4YJNgalaRPgSP5fNtNAmfT+YTk+A==
+
 react-dom@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"


### PR DESCRIPTION
## Calendly support

Users can now request a demo from a popup button in the main banner of the home page and contact page.

A contact page link has been added to the navbar as well. 