### PR TITLE
Nextjs Internal Redirects

### DIFF
--- a/components/landing-page/Pricing.jsx
+++ b/components/landing-page/Pricing.jsx
@@ -22,6 +22,9 @@ export default function Pricing() {
             <p className="mt-5 text-xl text-gray-500">
               Pricing is calculated in a <i>per-seat</i> arrangement. You'll only
               pay for firewalls which are active on the platform.
+              </p>
+              <p className="mt-1 text-xl text-gray-500">
+              Pricing is in USD but is calculated using your local currency at checkout.
             </p>
           </div>
           <a

--- a/components/layout/FooterTailwind.jsx
+++ b/components/layout/FooterTailwind.jsx
@@ -14,6 +14,7 @@ const navigation = {
   support: [
     {name: 'Contact', href: '/contact'},
     {name: 'Frequently Asked Questions', href: '/faq'},
+    {name: 'Roadmap', href: '/roadmap'},
   ],
   company: [
     {name: 'About', href: '/about'},
@@ -140,6 +141,7 @@ export default function Footer() {
               className="mt-4 sm:flex sm:max-w-md"
             >
               <input type="email" name="email" id="bd-email"
+                     placeholder="Enter your email"
                      className="appearance-none min-w-0 w-full bg-white border border-transparent rounded-md py-2 px-4 text-base text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white focus:border-white focus:placeholder-gray-400"
               />
               <input type="hidden" value="1" name="embed"/>

--- a/next.config.js
+++ b/next.config.js
@@ -7,4 +7,28 @@ module.exports = withMDX({
     webpack5: true,
   },
   pageExtensions: ['mdx', 'jsx', 'js', 'ts', 'tsx'],
+  async redirects() {
+    return [
+      {
+        source: '/docs',
+        destination: 'https://docs.mudmap.io/?ref=dashboard-docs',
+        permanent: true,
+      },
+      {
+        source: '/terms',
+        destination: 'https://mudmap.io/legal/terms?red=dashboard-docs',
+        permanent: true,
+      },
+      {
+        source: '/faq',
+        destination: 'https://www.notion.so/mudmapio/532a287009714c089b9730c88c64c0e5',
+        permanent: true,
+      },
+      {
+        source: '/roadmap',
+        destination: 'https://www.notion.so/mudmapio/6f7adbb8e3d54159963a6eb44496c326',
+        permanent: true
+      }
+    ]
+  },
 })


### PR DESCRIPTION
# Redirects

Next.js supports internal redirects using the `next.config.js` file. I am transitioning all next apps to this instead of using Render's redirects. This way they live inside each repo and are tracked via `git`. 

- Add next.js redirects 
- Create a link to the roadmap.
- Fix the placeholder for `email` in the footer.